### PR TITLE
Handle empty date range gracefully 

### DIFF
--- a/mac_data/data_sources/weather_underground/__init__.py
+++ b/mac_data/data_sources/weather_underground/__init__.py
@@ -1,34 +1,33 @@
 """Weather Underground Data Collection API
 """
 import logging
-import itertools as it
 
 from toolz import compose, juxt, map, curry
 from toolz.curried import get, do
 
-from mac_data.support import fapply, map_sleep, flatten, date_range
-from mac_data.output import CSVAdapter
-from .api import WAIT, query_api
+from mac_data.support import fapply, map_sleep, flatten, date_range  # NOQA
+from mac_data.output import CSVAdapter  # NOQA
+from .api import WAIT, query_api  # NOQA
 from .schema import WeatherUndergroundAPIResponse
-from .processing import process_response, extract_observations, process_metadata
-from .models import WeatherUndergroundObservation, WeatherUndergroundObservationSchema
+from .processing import process_response, extract_observations, process_metadata  # NOQA
+from .models import WeatherUndergroundObservation, WeatherUndergroundObservationSchema  # NOQA
 
 log = logging.getLogger(__name__)
 
-get_observations = compose(                   # query the api and extract observations
-    extract_observations,                     # get the list of observations from payload
+get_observations = compose(                   # extract observations from api
+    extract_observations,                     # get observations from payload
     get(0),                                   # drop the deserialization errors
     WeatherUndergroundAPIResponse().load,     # deserialize api response
     query_api                                 # query the api
 )
 
-collect_data = compose(                       # create observation models from api response
+collect_data = compose(         # create observation models from api response
     do(compose(log.info,
                "Created {} observations".format,
                len)),
-    process_response,                         # create observations models
-    fapply(map),                              # merge metadata into each observation
-    juxt(process_metadata, get_observations)  # process query params as metadata and api call
+    process_response,           # create observations models
+    fapply(map),                # merge metadata into each observation
+    juxt(process_metadata, get_observations)  # query params as metadata
 )
 
 

--- a/mac_data/data_sources/weather_underground/api.py
+++ b/mac_data/data_sources/weather_underground/api.py
@@ -26,8 +26,12 @@ def request_url(api_key, on_date, zipcode):
     :param zipcode: str zip code to query
     :return: str query url
     """
-    template = "http://api.wunderground.com/api/{key}/history_{date}/q/{zipcode}.json"
-    return template.format(key=api_key, date=on_date.strftime("%Y%m%d"), zipcode=zipcode)
+    template = ("http://api.wunderground.com/api/"
+                "{key}/history_{date}/q/{zipcode}.json")
+    return template.format(
+            key=api_key,
+            date=on_date.strftime("%Y%m%d"),
+            zipcode=zipcode)
 
 
 api_query_args = getargspec(request_url).args

--- a/mac_data/data_sources/weather_underground/processing.py
+++ b/mac_data/data_sources/weather_underground/processing.py
@@ -4,7 +4,7 @@ Defines functions to transform the deserialized API response into data models
 """
 import logging
 from toolz import compose, curry, merge
-from toolz.curried import get_in, map, do
+from toolz.curried import get_in, map
 from .models import WeatherUndergroundObservation
 from .api import api_query_args
 from mac_data.support import collect
@@ -73,9 +73,9 @@ def merge_metadata(metadata, observation):
 
 extract_observations = get_in(['history', 'observations'])
 
-create_model = compose(                         # create a model from observation data
+create_model = compose(
     WeatherUndergroundObservation.from_dict,    # create model
-    rename_keys(key_map)                        # filter and rename observation data
+    rename_keys(key_map)                        # filter and rename data
 )
 
 process_response = compose(                     # create a collection of models
@@ -83,9 +83,9 @@ process_response = compose(                     # create a collection of models
     map(create_model)
 )
 
-process_metadata = compose(                     # include query metadata in observation
-    merge_metadata,                             # merge (curried) with observations
-    dict,                                       # create dict from items
-    named_query_params(api_query_args),         # create query arg name, value pairs
-    collect                                     # collect api query args as a tuple
+process_metadata = compose(                 # include query metadata
+    merge_metadata,                         # merge with observations
+    dict,                                   # create dict from items
+    named_query_params(api_query_args),     # query arg name, value pairs
+    collect                                 # api query args as a tuple
 )

--- a/mac_data/marshmallow_ext/__init__.py
+++ b/mac_data/marshmallow_ext/__init__.py
@@ -1,4 +1,4 @@
-from fields import Union, Either, NullObject
+from fields import Union, Either, NullObject  # NOQA
 
 
 def fieldnames(schema):

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -2,10 +2,12 @@ from mac_data import api_keys
 
 
 def test_get_api_key(file_object):
+    expected_api_key = "the_api_key"
     s = '\n'.join([
         "[the_service_name]",
-        "api_key = the_api_key"
+        "api_key = %s" % expected_api_key
     ])
     file_object.write(s)
     file_object.seek(0)
-    assert api_keys.get_api_key(file_object, "the_service_name") == "the_api_key"
+    actual_api_key = api_keys.get_api_key(file_object, "the_service_name")
+    assert actual_api_key == expected_api_key

--- a/tests/test_mac_data.py
+++ b/tests/test_mac_data.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Tests for `mac_data` package."""
-import traceback
 from click.testing import CliRunner
 from mac_data import cli
 
@@ -16,4 +15,3 @@ def test_command_line_interface():
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert 'Show this message and exit.' in help_result.output
-

--- a/tests/test_mac_data.py
+++ b/tests/test_mac_data.py
@@ -1,29 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 """Tests for `mac_data` package."""
-
-import pytest
-
+import traceback
 from click.testing import CliRunner
-
 from mac_data import cli
-
-
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
-
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
-
-
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument."""
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
 
 
 def test_command_line_interface():
@@ -31,7 +11,9 @@ def test_command_line_interface():
     runner = CliRunner()
     result = runner.invoke(cli.main)
     assert result.exit_code == 0
-    assert 'Command line tool for data collection from web APIs' in result.output
+    assert ('Command line tool for data collection from web APIs'
+            in result.output)
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert 'Show this message and exit.' in help_result.output
+

--- a/tests/test_weather_underground.py
+++ b/tests/test_weather_underground.py
@@ -7,12 +7,9 @@ from click.testing import CliRunner
 
 import datetime
 import pytz
-import simplejson as json
-from marshmallow import Schema, fields
 from toolz import get_in, remove, compose
 from mac_data import cli
 from mac_data.support import dict_flatten
-from mac_data.output import CSVAdapter
 from mac_data.exceptions import APIRequestFailed
 from mac_data.data_sources import weather_underground as w
 from mac_data.data_sources.weather_underground.schema import NULL_VALUES
@@ -49,7 +46,9 @@ def test_schema_values(response):
             tz = pytz.timezone(raw_value['tzname'])
             dt_components = compose(int, raw_value.__getitem__)
             dt = datetime.datetime(*map(dt_components,
-                                        ['year', 'mon', 'mday', 'hour', 'min']))
+                                        ['year', 'mon', 'mday', 'hour', 'min']
+                                        )
+                                   )
             assert v == tz.localize(dt)
         elif v is None:
             assert raw_value in NULL_VALUES
@@ -96,15 +95,19 @@ def test_processing_pipeline(response):
             else:
                 return value
     with requests_mock.Mocker() as m:
-        m.get("http://api.wunderground.com/api/the_api_key/history_20170309/q/15217.json",
+        m.get("http://api.wunderground.com/api/the_api_key/"
+              "history_20170309/q/15217.json",
               text=response)
-        observations = w.collect_data("the_api_key", datetime.date(2017, 3, 9), "15217")
+        observations = w.collect_data("the_api_key",
+                                      datetime.date(2017, 3, 9),
+                                      "15217")
         raw_data = json.loads(response)
         raw_observations = raw_data['history']['observations']
         assert len(observations) == len(raw_observations)
         for ob, raw_ob in zip(observations, raw_observations):
             assert ob.zipcode == "15217"
-            # The api call is mocked to return a canned response from 2016-09-01
+            # The api call is mocked to return a canned response
+            # from 2016-09-01
             assert ob.recorded_at.date() == datetime.date(2016, 9, 1)
             assert ob.temperature == read_float(raw_ob['tempi'])
             assert ob.dew_point == read_float(raw_ob['dewpti'])
@@ -158,19 +161,24 @@ def test_collect_many(response):
     zipcodes = ["15217", "15216"]
     t = 0  # don't sleep during tests
     with requests_mock.Mocker() as m:
-        m.get("http://api.wunderground.com/api/the_api_key/history_20170309/q/15217.json",
+        m.get("http://api.wunderground.com/api/the_api_key/"
+              "history_20170309/q/15217.json",
               text=response)
-        m.get("http://api.wunderground.com/api/the_api_key/history_20170310/q/15216.json",
+        m.get("http://api.wunderground.com/api/the_api_key/"
+              "history_20170310/q/15216.json",
               text=response)
         raw_data = json.loads(response)
         raw_observations = raw_data['history']['observations']
         raw_observations = raw_observations + raw_observations
-        observations = list(w.collect_many("the_api_key", on_dates, zipcodes, t))
+        observations = list(w.collect_many("the_api_key", on_dates,
+                                           zipcodes, t)
+                            )
         assert len(observations) == len(raw_observations)
         for i, (ob, raw_ob) in enumerate(zip(observations, raw_observations)):
             zipcode = "15217" if i < len(observations)/2 else "15216"
             assert ob.zipcode == zipcode
-            # The api call is mocked to return a canned response from 2016-09-01
+            # The api call is mocked to return a canned response
+            # from 2016-09-01
             assert ob.recorded_at.date() == datetime.date(2016, 9, 1)
             assert ob.temperature == read_float(raw_ob['tempi'])
             assert ob.dew_point == read_float(raw_ob['dewpti'])
@@ -202,14 +210,16 @@ def test_collect_many_one(response):
     zipcodes = ["15217"]
     t = 0  # don't sleep during tests
     with requests_mock.Mocker() as m:
-        m.get("http://api.wunderground.com/api/the_api_key/history_20170309/q/15217.json",
+        m.get("http://api.wunderground.com/api/the_api_key/"
+              "history_20170309/q/15217.json",
               text=response)
         raw_data = json.loads(response)
         raw_observations = raw_data['history']['observations']
         obs_iter = list(w.collect_many("the_api_key", on_dates, zipcodes, t))
         for ob, raw_ob in zip(obs_iter, raw_observations):
             assert ob.zipcode == "15217"
-            # The api call is mocked to return a canned response from 2016-09-01
+            # The api call is mocked to return a canned response
+            # from 2016-09-01
             assert ob.recorded_at.date() == datetime.date(2016, 9, 1)
             assert ob.temperature == read_float(raw_ob['tempi'])
             assert ob.dew_point == read_float(raw_ob['dewpti'])
@@ -227,7 +237,6 @@ def test_collect_many_one(response):
             assert ob.condition == raw_ob['icon']
 
 
-
 def test_cli(response, tmpfile):
     runner = CliRunner()
     args = [
@@ -241,7 +250,8 @@ def test_cli(response, tmpfile):
         '--csv-out',
         tmpfile.name
     ]
-    url = "http://api.wunderground.com/api/the_api_key/history_20170309/q/15217.json"
+    url = ("http://api.wunderground.com/api"
+           "/the_api_key/history_20170309/q/15217.json")
     with requests_mock.Mocker() as m:
         m.get(url, text=response)
         result = runner.invoke(cli.main, args)
@@ -250,7 +260,9 @@ def test_cli(response, tmpfile):
         contents = tmpfile.read()
         lines = contents.splitlines()
         header = lines[0]
-        assert header == 'zipcode,recorded_at,temperature,dew_point,humidity,wind_speed,wind_gust,visibility,pressure,windchill,heat_index,precipitation,fog,rain,snow,condition'
+        assert header == ('zipcode,recorded_at,temperature,dew_point,humidity,'
+                          'wind_speed,wind_gust,visibility,pressure,windchill,'
+                          'heat_index,precipitation,fog,rain,snow,condition')
         assert len(lines) == 46
 
 
@@ -264,7 +276,28 @@ def test_cli_noop(response):
         '2017-03-09',
         '2017-03-10'
     ]
-    url = "http://api.wunderground.com/api/the_api_key/history_20170309/q/15217.json"
+    url = ("http://api.wunderground.com/api"
+           "/the_api_key/history_20170309/q/15217.json")
+    with requests_mock.Mocker() as m:
+        m.get(url, text=response)
+        result = runner.invoke(cli.main, args)
+        assert result.exit_code == 0
+
+
+def test_cli_empty_dates():
+    """test the weather underground cli"""
+    runner = CliRunner()
+    args = [
+        '-v',
+        '--key-file',
+        'tests/fixtures/test_key_file.ini',
+        'weather_underground',
+        '2017-03-09',
+        '2017-03-09',
+        '15217',
+    ]
+    url = ("http://api.wunderground.com/api"
+           "/the_api_key/history_20170309/q/15217.json")
     with requests_mock.Mocker() as m:
         m.get(url, text=response)
         result = runner.invoke(cli.main, args)


### PR DESCRIPTION
The date range is exclusive of the end date; consistent with the builtin `range` function. This means that when the start and end date are the same, an empty range is produced.

Handle this by issuing a warning with a helpful message instead of throwing a cryptic exception.